### PR TITLE
Set correct size in OpenCV when changing grabber resolution

### DIFF
--- a/src/grabbers/image/cameragrabber.cpp
+++ b/src/grabbers/image/cameragrabber.cpp
@@ -128,6 +128,9 @@ bool CameraGrabber::createCamera()
         setSize(size);
     }
 
+    cvSetCaptureProperty( m_camera, CV_CAP_PROP_FRAME_WIDTH, m_size.width());
+    cvSetCaptureProperty( m_camera, CV_CAP_PROP_FRAME_HEIGHT, m_size.height());
+
     return true;
 }
 


### PR DESCRIPTION
When you set the size in the CameraGrabber, the image actually gets scaled to the desired resolution, using this commit you do actually get the right resolution from the camera
